### PR TITLE
Require base >= 4.11.

### DIFF
--- a/Ranged-sets.cabal
+++ b/Ranged-sets.cabal
@@ -23,7 +23,7 @@ author: Paul Johnson
 extra-source-files: CHANGES.txt README.txt
 
 library
-    build-depends: HUnit -any, QuickCheck >=2, base >=4 && <5
+    build-depends: HUnit -any, QuickCheck >=2, base >=4.11 && <5
     exposed-modules: Data.Ranged Data.Ranged.Ranges
                  Data.Ranged.RangedSet Data.Ranged.Boundaries
     exposed: True


### PR DESCRIPTION
Ranged-sets-0.4.0 fails to build with base <= 10 / ghc 8.2 due to the missing Semigroup
class.

```
Data/Ranged/RangedSet.hs:74:31: error:
    Not in scope: type constructor or class ‘Semigroup’
   |
74 | instance DiscreteOrdered a => Semigroup (RSet a) where
   |                               ^^^^^^^^^
```

This is causing me build failures trying to build postgrest with older ghc versions.

Could you please also apply this change via hackage's "edit package information" to
ensure that cabal chooses Ranged-sets <0.4 when building with older ghc versions?

If you like, I'd be happy to test and submit a PR for a Ranged-sets-0.4.1 that builds
with older base versions.
