### PR TITLE
Upstream Alex changes

### DIFF
--- a/Data/Ranged/Boundaries.hs
+++ b/Data/Ranged/Boundaries.hs
@@ -76,7 +76,23 @@ instance DiscreteOrdered Int where
    adjacent = boundedAdjacent
    adjacentBelow = boundedBelow
 
+instance DiscreteOrdered Word where
+   adjacent = boundedAdjacent
+   adjacentBelow = boundedBelow
+
 instance DiscreteOrdered Word8 where
+   adjacent = boundedAdjacent
+   adjacentBelow = boundedBelow
+
+instance DiscreteOrdered Word16 where
+   adjacent = boundedAdjacent
+   adjacentBelow = boundedBelow
+
+instance DiscreteOrdered Word32 where
+   adjacent = boundedAdjacent
+   adjacentBelow = boundedBelow
+
+instance DiscreteOrdered Word64 where
    adjacent = boundedAdjacent
    adjacentBelow = boundedBelow
 

--- a/Data/Ranged/Boundaries.hs
+++ b/Data/Ranged/Boundaries.hs
@@ -20,6 +20,7 @@ module Data.Ranged.Boundaries (
 ) where
 
 import Data.Ratio
+import Data.Word
 import Test.QuickCheck
 
 infix 4 />/
@@ -72,6 +73,10 @@ instance DiscreteOrdered Char where
    adjacentBelow = boundedBelow
 
 instance DiscreteOrdered Int where
+   adjacent = boundedAdjacent
+   adjacentBelow = boundedBelow
+
+instance DiscreteOrdered Word8 where
    adjacent = boundedAdjacent
    adjacentBelow = boundedBelow
 

--- a/Data/Ranged/RangedSet.hs
+++ b/Data/Ranged/RangedSet.hs
@@ -69,7 +69,7 @@ infixl 5 -<=-, -<-, -?-
 -- | An RSet (for Ranged Set) is a list of ranges.  The ranges must be sorted
 -- and not overlap.
 newtype DiscreteOrdered v => RSet v = RSet {rSetRanges :: [Range v]}
-   deriving (Eq, Show)
+   deriving (Show, Eq, Ord)
 
 instance DiscreteOrdered a => Semigroup (RSet a) where
    (<>) = rSetUnion


### PR DESCRIPTION
The [Alex](https://github.com/haskell/alex) project includes a full copy of Ranged-sets 0.3.0. As explained in the [NOTE file](https://github.com/haskell/alex/blob/master/NOTE.txt), the intent was to minimize the number of dependencies in the Haskell Platform. With the Haskell Platform now deprecated, this feels unnecessary: Alex could just properly depend on Ranged-sets instead of maintaining a fork.

With that intent in mind, this PR upstreams two small changes made to the Alex copy of Ranged-sets: it adds an instance of `DiscreteOrdered` for `Word8`, and adds an `Ord` instance to `RSet`. I have confirmed locally that this is enough for `Alex` to work with Ranged-sets 0.4.0. Additionally, this PR adds instances of `DiscreteOrdered` for all other `Word` types.

Let me know what you think!